### PR TITLE
Add CLAUDE.md for AI assistant guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and other AI assistants) working in this repository.
+See [README.md](README.md) for end-user/usage detail; this file is the agent-facing reference.
+
+## Project overview
+
+Whisper Flow is a real-time, streaming speech-to-text service built on OpenAI Whisper and
+served via FastAPI. It splits incoming audio into temporal **tumbling windows** to emit partial
+transcripts at sub-500ms latency. Shipped as the Python package `whisperflow` (v1.1.0,
+Python 3.8+, developed/tested on 3.12).
+
+## Commands
+
+Everything runs through [run.sh](run.sh). The `-local` target rebuilds `.venv` from scratch;
+the other targets assume the venv is already activated (`source .venv/bin/activate`).
+
+| Command | What it does |
+|---------|--------------|
+| `./run.sh -local` | Fresh `.venv` + install deps + format + lint + tests (first-time setup) |
+| `./run.sh -test` | black + pylint + pytest — the inner-loop check before committing |
+| `./run.sh -run-server` | uvicorn FastAPI server on port 8181 |
+| `./run.sh -benchmark` | Start server, run `tests/benchmark` (LibriSpeech WER/latency), stop |
+| `./run.sh -docker` | Build and run the container on port 8888 |
+
+Running a single test (venv activated): `pytest tests/test_streaming.py -v`
+
+## Quality gates — must pass
+
+CI enforces these via [Dockerfile.test](Dockerfile.test). `./run.sh -test` runs the same checks
+locally:
+
+- `black whisperflow tests` — formatting (no diffs allowed)
+- `pylint --fail-under=9.9 whisperflow tests` — near-perfect lint score required
+- `pytest --ignore=tests/benchmark --cov-fail-under=95 --cov whisperflow` — **95% coverage**
+
+Implication: every code change needs accompanying tests to keep coverage ≥95%, and all code
+must be black-formatted and pass pylint at 9.9+. Run `./run.sh -test` before considering work
+done.
+
+## Architecture & key files
+
+- [whisperflow/transcriber.py](whisperflow/transcriber.py) — Whisper model loading and
+  inference: `get_model()`, `transcribe_pcm_chunks()`, `transcribe_pcm_chunks_async()`
+- [whisperflow/streaming.py](whisperflow/streaming.py) — tumbling-window streaming logic,
+  `TranscribeSession`
+- [whisperflow/fast_server.py](whisperflow/fast_server.py) — FastAPI app: WebSocket `/ws`,
+  `GET /health`, `POST /transcribe_pcm_chunk`
+- [whisperflow/chat_room.py](whisperflow/chat_room.py) — multi-user chat
+- [whisperflow/audio/microphone.py](whisperflow/audio/microphone.py) — audio input
+- [whisperflow/models/](whisperflow/models/) — bundled `tiny.en.pt` model
+- [tests/](tests/) — pytest suite. `tests/benchmark/` and `tests/audio/` are excluded from the
+  coverage gate.
+
+## Environment gotchas
+
+- **Python 3.12** preferred — `run.sh` auto-selects `python3.12` when available.
+- **`setuptools<70`** pin is required for `openai-whisper` compatibility (see `run.sh`).
+- **PortAudio** system dependency is required for PyAudio:
+  `brew install portaudio` (macOS) / `apt-get install portaudio19-dev` (Debian/Ubuntu).
+- **Audio format**: 16 kHz, mono, 16-bit signed integer (int16) PCM.
+- **Ports**: 8181 when run locally, 8888 in Docker.
+
+## Conventions
+
+- Match the existing style; keep modules small and focused.
+- Add tests with every code change (the 95% coverage gate enforces this).
+- Always run `./run.sh -test` and ensure it is green before finishing.

--- a/docs/monetization-feedback-loop.md
+++ b/docs/monetization-feedback-loop.md
@@ -1,0 +1,134 @@
+# Monetization Feedback Loop
+
+A continuous, evidence-driven cycle for finding and growing revenue for WhisperFlow and the
+products built on it ([Linga, LitMind, MetaVox, SlideCrafter](plans.md)). Strategy is never
+"decided once" — it is a loop we run on a fixed cadence: **Plan → Do → Measure → (Learn) →
+start over.**
+
+The point of the loop is to treat every monetization idea from [monetizations.md](monetizations.md)
+as a hypothesis to be tested cheaply, kept if it works, and dropped if it doesn't.
+
+```
+        ┌───────────────────────────────────────────────┐
+        │                                               │
+        ▼                                               │
+   ┌─────────┐      ┌─────────┐      ┌──────────┐      ┌─┴────────┐
+   │  PLAN   │ ───▶ │   DO    │ ───▶ │ MEASURE  │ ───▶ │  LEARN   │
+   │hypothesis│      │ run the │      │ collect  │      │ decide:  │
+   │ + metric │      │ smallest│      │ the data │      │ keep /   │
+   │ + target │      │  test   │      │ vs target│      │ pivot /  │
+   └─────────┘      └─────────┘      └──────────┘      │  kill    │
+        ▲                                               └─┬────────┘
+        │                                                 │
+        └─────────────────────────────────────────────────┘
+                         feeds the next Plan
+```
+
+**Cadence:** one full turn of the loop per **2-week iteration**, reviewed in a short retro.
+Run only **1–2 hypotheses at a time** so the Measure step can attribute the result.
+
+---
+
+## 1. PLAN — form a hypothesis
+
+Pick one monetization lever and turn it into a falsifiable bet. Write it down before doing
+anything.
+
+- **Choose a lever** from [monetizations.md](monetizations.md): paid support, dual licensing,
+  freemium premium features, SaaS, sponsored development, donations, courses, enterprise
+  customization.
+- **Choose a segment**: open-source library users, a single product surface (e.g. MetaVox
+  SaaS), or an enterprise buyer.
+- **Write the hypothesis** in one sentence:
+  > "We believe *[segment]* will pay for *[offer]* because *[value]*. We'll know it's true if
+  > *[metric]* reaches *[target]* by *[date]*."
+- **Define one primary metric and a target** (see the metric menu below). Targets are
+  pass/fail thresholds, not vanity goals.
+- **Define the smallest test** that can validate or kill the hypothesis (a pricing page, a
+  "contact us for enterprise" button, a single sponsor email, a landing page).
+
+**Exit criteria for PLAN:** a written hypothesis, one primary metric, a numeric target, and a
+test that fits inside one iteration.
+
+## 2. DO — run the smallest test
+
+Build the least amount possible to get a real signal. Bias toward fake-door and
+concierge tests over full features.
+
+- **Demand tests:** pricing/landing pages, "Buy / Contact sales" buttons that capture intent,
+  waitlists.
+- **Manual-first delivery:** deliver the paid value by hand (concierge consulting, a manually
+  run MetaVox job) before automating it.
+- **Packaging tests:** publish a commercial-license page, a sponsorship tier, a GitHub
+  Sponsors / Open Collective page.
+- **Instrument everything** as you ship it — the Measure step is only as good as the events you
+  capture (see Instrumentation below).
+
+**Exit criteria for DO:** the test is live, instrumented, and exposed to real users for the
+iteration window.
+
+## 3. MEASURE — collect the data vs. the target
+
+Compare the primary metric against the target set in PLAN. Be honest; a "no" is a successful
+experiment.
+
+### Metric menu (pick the one that matches the lever)
+
+| Lever | Primary metric | Example target |
+|-------|----------------|----------------|
+| SaaS / freemium | Free → paid conversion rate | ≥ 3% of activated users |
+| SaaS | MRR / net revenue retention | First $X MRR; NRR ≥ 100% |
+| Pricing test | Willingness-to-pay (clicks on a priced tier) | ≥ N intent signals/week |
+| Dual licensing | Qualified commercial-license leads | ≥ N inbound/quarter |
+| Paid support | Closed support/consulting contracts | ≥ 1 paying account |
+| Sponsorship / donations | Recurring sponsor revenue | First $X/month committed |
+| Courses | Pre-orders / completed sales | ≥ N pre-orders before building |
+| Any | CAC vs. LTV | LTV : CAC ≥ 3 : 1 |
+
+### Supporting / guardrail metrics
+
+- Activation rate (users who reach first transcription value)
+- Retention / churn
+- Funnel drop-off (visit → signup → activate → pay)
+- Cost to serve (inference/compute per active user — relevant given WhisperFlow's latency goals)
+- Community health (stars, contributors, issues) so monetization doesn't erode the open-source base
+
+**Exit criteria for MEASURE:** a single recorded result — *metric, actual value, target, met /
+not met* — plus any surprising qualitative signal.
+
+## 4. LEARN — decide, then loop
+
+Close the iteration with an explicit decision. This decision becomes the seed of the next PLAN.
+
+- **Keep / double down** — target met: scale it, raise the target, invest in automation.
+- **Pivot** — partial signal: change the segment, price, or packaging and re-test.
+- **Kill** — no signal: archive the hypothesis (record *why*) and pick a different lever.
+
+Log every iteration in the ledger below so the loop has memory and we don't re-test dead ideas.
+
+### Iteration ledger
+
+| # | Dates | Hypothesis (lever / segment) | Primary metric | Target | Result | Decision |
+|---|-------|------------------------------|----------------|--------|--------|----------|
+| 1 | _TBD_ | _e.g. SaaS / MetaVox creators_ | _e.g. free→paid %_ | _3%_ | _—_ | _Keep / Pivot / Kill_ |
+| 2 | | | | | | |
+| 3 | | | | | | |
+
+---
+
+## Instrumentation (so MEASURE is trustworthy)
+
+- Capture funnel events: landing view → signup → activation (first transcript) → upgrade click
+  → payment.
+- Tag traffic by experiment/segment so results are attributable to one hypothesis.
+- Track unit economics per active user (compute/inference cost) alongside revenue.
+- Keep a lightweight dashboard; the loop depends on data being visible at retro time.
+
+## Operating principles
+
+- **One loop, fixed cadence** — review every iteration; don't let a test run open-ended.
+- **Smallest test first** — validate demand before building features.
+- **1–2 hypotheses at a time** — keep results attributable.
+- **A "no" is a win** — killing a bad bet cheaply is the loop working as designed.
+- **Protect the open-source core** — monetization must not degrade the free experience that
+  drives adoption (community health is a guardrail metric).

--- a/docs/zero-to-money-plan.md
+++ b/docs/zero-to-money-plan.md
@@ -1,0 +1,151 @@
+# WhisperFlow: 0 → Money Plan
+
+A concise, step-by-step plan to go from zero revenue to a sustainable business, paced for a
+**part-time solo founder (~10–15 hrs/week)**. Milestones are in **weeks from Week 1**.
+
+This is the *strategy*. Run each step through the
+[monetization-feedback-loop.md](monetization-feedback-loop.md) (Plan → Do → Measure → Learn).
+Levers come from [monetizations.md](monetizations.md); the broader product ideas in
+[plans.md](plans.md) are deliberately **out of scope** until after ramen profitability.
+
+---
+
+## TL;DR
+
+- **Don't sell "another real-time STT API."** That market is commoditized (Deepgram,
+  AssemblyAI, OpenAI, Speechmatics, Google). A part-time founder can't win on scale or price.
+- **Sell WhisperFlow's two real edges:** **sub-500ms latency** + **self-hostable (audio never
+  leaves the customer's infra)**. That attracts privacy- and cost-sensitive buyers.
+- **The wedge is one narrative, two phases:**
+  1. **Cash bridge — a fixed-price integration service.** Fastest first dollar, zero product
+     build, and it doubles as a design-partner funnel that tells you what to build.
+  2. **Compounding product — a thin hosted + self-host transcription service** for one narrow
+     ICP, built only as design partners pull it.
+
+| Milestone | Target week | What it means |
+|-----------|:-----------:|---------------|
+| **M1** First paying customer | ~Week 6 | First dollar in (paid integration sprint / pilot) |
+| **M2** First $1k MRR | ~Week 16 | A few recurring paying accounts |
+| **M3** Ramen profitable | ~Week 30–40 | Recurring revenue covers your monthly burn |
+
+---
+
+## Positioning
+
+> **"The real-time, self-hostable, cost-predictable transcription engine."**
+> Sub-500ms latency. Run it in your own cloud — audio never leaves your infrastructure.
+
+**Pick ONE narrow ICP** (the plan is ICP-agnostic; swap if you have a stronger candidate).
+**Default recommendation:** *developers building live voice features* — live captioning, voice
+agents, telehealth/scribing — who need low latency **and** on-prem/privacy and want predictable
+cost. Narrow beats broad: a specific buyer makes outreach, messaging, and pricing concrete.
+
+---
+
+## The plan, week by week
+
+Paced for ~10–15 hrs/week. Each 2-week block is one turn of the feedback loop.
+
+### Phase A → M1: First paying customer (target ~Week 6)
+
+- **Week 1 — Set the trap.** Pick the ONE ICP. Write a one-line offer. Stand up a simple
+  landing page with three calls to action: a priced **"integration sprint,"** a **hosted-beta
+  waitlist,** and **"commercial / self-host license — contact."** Add funnel instrumentation
+  (visit → CTA click → call booked) per the feedback loop's Instrumentation section.
+- **Week 2 — Mine warm demand.** Work existing signals: repo stargazers, GitHub issues/users,
+  your network, and 1–2 communities where the ICP lives. ~20–30 targeted outreach touches.
+  Lead with the fixed-price integration sprint (concrete, low-risk for the buyer).
+- **Weeks 3–4 — Close one.** Run discovery calls. Close **1 paid integration sprint**, paid
+  pilot, or a **prepaid design-partner slot**. → **M1: first dollar in.**
+- **Weeks 5–6 — Deliver by hand (concierge).** Integrate WhisperFlow into their product
+  manually. Extract the three things that drive Phase B: (a) what they'd pay *monthly* for,
+  (b) the #1 missing feature, (c) a testimonial / mini case study.
+
+### Phase B → M2: First $1k MRR (target ~Week 16)
+
+- **Weeks 6–8 — Minimum hosted product.** Build the thinnest product layer on top of the
+  existing FastAPI server ([whisperflow/fast_server.py](../whisperflow/fast_server.py): `/ws`,
+  `/health`, `/transcribe_pcm_chunk`): **API keys + per-minute metering + Stripe usage billing
+  + self-serve signup.** No new ML work — the engine already exists.
+- **Weeks 8–10 — First recurring revenue.** Convert the Phase-A design partner(s) onto a paid
+  monthly plan. Onboard 2–4 waitlist leads as paying beta accounts.
+- **Weeks 10–14 — Tighten the funnel.** One hypothesis per iteration: pricing, activation
+  (time-to-first-transcript), and a **self-host/commercial-license tier** for any privacy buyer
+  who can't use the cloud. Kill what doesn't convert; double down on what does.
+- **Weeks 14–16 — Cross $1k MRR** across hosted usage + license + any retainer. → **M2.**
+
+### Phase C → M3: Ramen profitable (target ~Week 30–40, depends on your burn)
+
+- **Weeks 16–24 — Double down on what worked.** Keep only the 1–2 channels that actually
+  converted in Phase B (content built on the **latency/benchmark story** — you already have
+  real numbers in the README; the OSS repo as a funnel; design-partner referrals). Productize
+  the most-requested feature into a higher-priced tier.
+- **Weeks 24–40 — Stack recurring + license revenue.** Grow MRR alongside a small number of
+  **annual self-host/commercial licenses** (lumpy but high-value — a few of these move the
+  needle fast) until recurring revenue covers your personal monthly burn. → **M3.**
+
+> **Assumption to fill in:** "ramen profitable" = your real monthly cost of living (call it
+> **$Z/mo**). The Week 30–40 target assumes a modest $Z; set your number and the date shifts
+> accordingly. This is the one milestone that depends on a fact only you know.
+
+---
+
+## Pricing & packaging
+
+Starting points — treat every number as a **hypothesis to validate** via the feedback loop, not
+a commitment.
+
+| Tier | Shape | Starting hypothesis |
+|------|-------|---------------------|
+| **Integration sprint** (services) | Fixed-price, time-boxed delivery | One-off fee; your fastest cash + design-partner funnel |
+| **Hosted** | Per audio-minute + a monthly minimum | Usage-based; minimum makes small accounts worth serving |
+| **Self-host / commercial license + SLA** | Annual | High-value, lumpy; the dual-license lever from [monetizations.md](monetizations.md) |
+
+Positioning anchor: customers pay for **predictable cost + privacy + latency**, not raw
+transcription minutes.
+
+## Distribution (cheap first, no paid ads early)
+
+1. **Founder-led outreach** — direct, targeted, to the one ICP. This is the whole game in
+   Phase A.
+2. **OSS repo as funnel** — add a clear "hosted version / commercial license" CTA in the README
+   and repo. Stars and issues are warm leads.
+3. **Latency/benchmark content** — you already have real sub-500ms / ~7% WER numbers. Turn the
+   benchmark into posts; technical buyers trust numbers.
+4. **Design-partner referrals** — happy Phase-A customers introduce the next ones.
+
+## What we build vs. refuse to build
+
+- **Build (only this, in Phase B):** API keys, per-minute metering, Stripe billing, a landing
+  page, basic onboarding.
+- **Refuse until a paying customer pulls it:** dashboards, multi-region, new/larger models,
+  fancy UI, and the full product apps in [plans.md](plans.md) (MetaVox, Linga, LitMind,
+  SlideCrafter). **Those are post-ramen expansion bets, not the wedge.**
+
+## Operating cadence
+
+Run the whole plan through [monetization-feedback-loop.md](monetization-feedback-loop.md):
+**1–2 hypotheses per 2-week iteration**, each with a metric and a target, logged in the
+iteration ledger. A "no" is a successful experiment — kill cheaply and move on.
+
+## Risks & honest caveats
+
+| Risk | Mitigation |
+|------|------------|
+| Part-time pace slips the timeline | Keep scope brutally small; one hypothesis at a time; protect a fixed weekly block |
+| STT is commoditized | Don't compete on raw API — sell latency + self-host + predictable cost to a narrow ICP |
+| Self-host/enterprise sales cycles are long and lumpy | Lead with the fast services/hosted revenue; treat licenses as upside, not the base case |
+| Single-founder bus factor | Document as you go (these docs); automate billing early; avoid bespoke per-customer code |
+| Building before demand is proven | The "refuse to build" list is the guardrail; nothing ships until a customer pulls it |
+
+---
+
+## Milestone summary
+
+| Milestone | Target week | Definition of done | Primary metric |
+|-----------|:-----------:|--------------------|----------------|
+| **M1** First paying customer | ~Week 6 | First paid sprint / pilot / prepaid slot closed | First dollar collected |
+| **M2** First $1k MRR | ~Week 16 | Recurring revenue ≥ $1k/mo across hosted + license + retainer | MRR |
+| **M3** Ramen profitable | ~Week 30–40* | Recurring revenue ≥ your monthly burn ($Z) | MRR vs. personal burn |
+
+\* Depends on your actual monthly burn ($Z) — set it and the date firms up.


### PR DESCRIPTION
Add a root CLAUDE.md capturing the run.sh command map, CI quality gates (black, pylint >=9.9, 95% coverage), the architecture key-files map, and environment gotchas (python3.12, setuptools<70 pin, PortAudio, PCM format, port 8181/8888).